### PR TITLE
Change URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
 * Python, Flask, HTML, CSS, Heroku
 
 ## Deployment URL:
-* URL: https://breast-cancerapi.herokuapp.com/predict
+* URL: https://breast-cancerapi.herokuapp.com/


### PR DESCRIPTION
I came across your project, and noticed that the URL mentioned shows error 405 as follows. 
<img width="1440" alt="Screen Shot 2020-12-27 at 11 35 04 PM" src="https://user-images.githubusercontent.com/30956619/103177032-85b10100-489c-11eb-8c26-6f634029199f.png">

Replaced it with the right URL.
<img width="1440" alt="Screen Shot 2020-12-27 at 11 35 14 PM" src="https://user-images.githubusercontent.com/30956619/103177033-86499780-489c-11eb-8fe5-282c761462d0.png">

